### PR TITLE
feat(143715): Adiciona novos campos e método de busca na view de candidanto

### DIFF
--- a/candidatos/serializer/concurso_candidato.py
+++ b/candidatos/serializer/concurso_candidato.py
@@ -6,10 +6,34 @@ from rest_framework.validators import ValidationError
 class ConcursoCandidatoSerializer(serializers.ModelSerializer):
     candidato = serializers.SerializerMethodField(read_only=True)
     reclassificacoes = serializers.SerializerMethodField(read_only=True)
+    concurso_uuid = serializers.SerializerMethodField(read_only=True)
+    concurso_nome = serializers.SerializerMethodField(read_only=True)
+    concurso_candidato_uuid = serializers.SerializerMethodField(read_only=True)
+
     class Meta:
         model = ConcursoCandidato
         fields = '__all__'
         read_only_fields = ['criado_em', 'atualizado_em', 'esta_ativo']
+
+    def get_concurso_candidato_uuid(self, obj):
+        """UUID da linha na tabela candidatos_concursocandidato (ConcursoCandidato)."""
+        return str(obj.uuid) if getattr(obj, 'uuid', None) else None
+
+    def get_concurso_uuid(self, obj):
+        """Retorna o UUID do concurso (campo do modelo ou do lote)."""
+        if getattr(obj, 'concurso_uuid', None):
+            return str(obj.concurso_uuid)
+        lote = getattr(obj, 'lote', None)
+        if lote and getattr(lote, 'concurso_uuid', None):
+            return str(lote.concurso_uuid)
+        return None
+
+    def get_concurso_nome(self, obj):
+        """Retorna o nome do concurso (do lote, quando existir)."""
+        lote = getattr(obj, 'lote', None)
+        if lote and getattr(lote, 'concurso_nome', None):
+            return lote.concurso_nome
+        return None
 
     def get_candidato(self, obj):
         c = obj.candidato

--- a/candidatos/views/candidatos.py
+++ b/candidatos/views/candidatos.py
@@ -1,12 +1,15 @@
 from pathlib import Path
 from django.conf import settings
+from django.db.models import Q
 from django.http import FileResponse, Http404
 from rest_framework import viewsets, filters, status
+from rest_framework.decorators import action
 from rest_framework.response import Response
 from django_filters.rest_framework import DjangoFilterBackend
 from candidatos.models import Candidato, ConcursoCandidato
 from candidatos.serializers import (
     CandidatoSerializer,
+    ConcursoCandidatoSerializer,
     CandidatosLoteCreateSerializer,
 )
 from candidatos.service.candidato_lote_service import processar_criacao_candidatos_lote
@@ -15,9 +18,11 @@ from candidatos.service.candidato_lote_service import processar_criacao_candidat
 class CandidatoViewSet(viewsets.ModelViewSet):
     queryset = Candidato.objects.all()
     serializer_class = CandidatoSerializer
+    lookup_field = 'uuid'
+    lookup_url_kwarg = 'uuid'
     filter_backends = [DjangoFilterBackend, filters.SearchFilter, filters.OrderingFilter]
     filterset_fields = ['status', 'genero', 'cidade', 'estado']
-    search_fields = ['nome', 'cpf', 'email', 'cidade']
+    search_fields = ['nome', 'cpf', 'email', 'cidade', 'rg', 'registro_funcional']
     ordering_fields = ['nome', 'data_nascimento', 'created_at']
     ordering = ['nome']
 
@@ -26,3 +31,54 @@ class CandidatoViewSet(viewsets.ModelViewSet):
         input_serializer.is_valid(raise_exception=True)
         resp_data, status_code = processar_criacao_candidatos_lote(input_serializer.validated_data)
         return Response(resp_data, status=status_code)
+
+    @action(methods=['get'], detail=False, url_path='buscar')
+    def buscar(self, request):
+        """
+        Busca por nome, CPF, RG ou registro funcional na tabela candidatos_concursocandidato.
+        Retorna lista de candidatos com concursos (apenas os ConcursoCandidato que bateram na busca).
+        Query params: nome, cpf, rg, registro_funcional (pelo menos um obrigatório).
+        """
+        nome = request.query_params.get('nome', '').strip()
+        cpf = request.query_params.get('cpf', '').strip()
+        rg = request.query_params.get('rg', '').strip()
+        registro_funcional = request.query_params.get('registro_funcional', '').strip()
+
+        if not any([nome, cpf, rg, registro_funcional]):
+            return Response(
+                {'detail': 'Informe pelo menos um parâmetro: nome, cpf, rg ou registro_funcional.'},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        q_obj = Q()
+        if nome:
+            q_obj |= Q(candidato__nome__icontains=nome)
+        if cpf:
+            q_obj |= Q(candidato__cpf__icontains=cpf)
+        if rg:
+            q_obj |= Q(candidato__rg__icontains=rg)
+        if registro_funcional:
+            q_obj |= Q(candidato__registro_funcional__icontains=registro_funcional)
+
+        cc_qs = (
+            ConcursoCandidato.objects
+            .filter(q_obj)
+            .select_related('candidato', 'lote')
+            .order_by('candidato__nome')[:300]
+        )
+        cc_list = list(cc_qs)
+
+        candidatos_por_uuid = {}
+        for cc in cc_list:
+            c = cc.candidato
+            if c.uuid not in candidatos_por_uuid:
+                candidatos_por_uuid[c.uuid] = {'candidato': c, 'concursos': []}
+            candidatos_por_uuid[c.uuid]['concursos'].append(cc)
+
+        resultado = []
+        for c in candidatos_por_uuid.values():
+            item = CandidatoSerializer(c['candidato']).data
+            item['concursos'] = ConcursoCandidatoSerializer(c['concursos'], many=True).data
+            resultado.append(item)
+
+        return Response(resultado)


### PR DESCRIPTION
- Expande o `ConcursoCandidatoSerializer` com campos para UUID e nome do concurso.
- Implementa método de busca na view `CandidatoViewSet` para filtrar candidatos por nome, CPF, RG e registro funcional, retornando os concursos associados.

[AB#143250](https://dev.azure.com/SME-Spassu/bd1a795a-42dd-4c65-8d4e-99a11b87f228/_workitems/edit/143250) [AB#143715](https://dev.azure.com/SME-Spassu/bd1a795a-42dd-4c65-8d4e-99a11b87f228/_workitems/edit/143715)