### PR TITLE
feat(146205)-corrige roteamento de arquivos estáticos e swagger

### DIFF
--- a/candidatos/views/__init__.py
+++ b/candidatos/views/__init__.py
@@ -1,5 +1,4 @@
 from .candidatos import CandidatoViewSet
-from .swagger import SwaggerFromFileView
 from .parametrizacao import ParametrizacaoViewSet
 
-__all__ = ['CandidatoViewSet', 'SwaggerFromFileView', 'ParametrizacaoViewSet']
+__all__ = ['CandidatoViewSet', 'ParametrizacaoViewSet']

--- a/candidatos/views/swagger.py
+++ b/candidatos/views/swagger.py
@@ -1,9 +1,0 @@
-from django.conf import settings
-from drf_spectacular.views import SpectacularSwaggerView
-
-
-class SwaggerFromFileView(SpectacularSwaggerView):
-    def _get_schema_url(self, request):
-        url = super()._get_schema_url(request)
-        url_com_prefixo = f'{settings.MS_PATH}{url}' if settings.DJANGO_ENVIRONMENT != 'local' else url
-        return url_com_prefixo

--- a/config/settings.py
+++ b/config/settings.py
@@ -15,7 +15,8 @@ MS_PATH = os.environ.get('MS_PATH', '/ms-candidatos')
 BASE_DIR = Path(__file__).resolve().parent.parent
 SECRET_KEY = os.environ.get('SECRET_KEY', 'django-insecure-your-secret-key-here')
 DEBUG = os.environ.get('DEBUG', 'True').lower() == 'true'
-ALLOWED_HOSTS = os.environ.get('ALLOWED_HOSTS', '*').split(',')
+ALLOWED_HOSTS = ['localhost', '127.0.0.1', '0.0.0.0', 'qa-api-sigla.sme.prefeitura.sp.gov.br', 'hom-api-sigla.sme.prefeitura.sp.gov.br']
+CSRF_TRUSTED_ORIGINS = ['https://qa-api-sigla.sme.prefeitura.sp.gov.br', 'https://hom-api-sigla.sme.prefeitura.sp.gov.br']
 
 # Application definition
 INSTALLED_APPS = [
@@ -110,8 +111,18 @@ USE_I18N = True
 USE_TZ = True
 
 # Static files (CSS, JavaScript, Images)
-STATIC_URL = '/static/'
-STATIC_ROOT = BASE_DIR / 'staticfiles'
+
+STATIC_ROOT = os.path.join(BASE_DIR, 'staticfiles')
+
+_ms_path_segment = (MS_PATH or '/ms-candidatos').strip('/')
+if DJANGO_ENVIRONMENT != 'local':
+    STATIC_URL = f'/{_ms_path_segment}/django_static/'
+    MEDIA_URL = f'/{_ms_path_segment}/media/'
+else:
+    STATIC_URL = '/django_static/'
+    MEDIA_URL = '/media/'
+
+MEDIA_ROOT = os.path.join(BASE_DIR, 'media')
 
 # Default primary key field type
 DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'

--- a/config/urls.py
+++ b/config/urls.py
@@ -1,16 +1,32 @@
 from django.contrib import admin
+from django.conf import settings
 from django.urls import path, include
+from django.conf.urls.static import static
 from django.http import JsonResponse
 from drf_spectacular.views import SpectacularAPIView, SpectacularSwaggerView
-from candidatos.views import SwaggerFromFileView
 
 def healthcheck(_request):
     return JsonResponse({"status": "ok"})
 
-urlpatterns = [
+_core_urlpatterns = [
     path('admin/', admin.site.urls),
     path('api/v1/', include('candidatos.urls')),
     path('api/schema/', SpectacularAPIView.as_view(), name='schema'),
-    path('api/docs/', SwaggerFromFileView.as_view(), name='swagger-ui'),
+    path('api/docs/', SpectacularSwaggerView.as_view(url_name='schema'), name='swagger-ui'),
     path('', healthcheck, name='healthcheck'),
 ]
+
+_static_urlpatterns = (
+    static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)
+    + static(settings.STATIC_URL, document_root=settings.STATIC_ROOT)
+)
+
+# Só as rotas da app entram sob MS_PATH. Static/media ficam na raiz (/django_static/, /media/)
+# para bater com STATIC_URL e MEDIA_URL usados pelo admin e pelo collectstatic.
+if getattr(settings, 'DJANGO_ENVIRONMENT', 'local') != 'local':
+    _ms_prefix = getattr(settings, 'MS_PATH', '/ms-candidatos').strip('/')
+    urlpatterns = [
+        path(f'{_ms_prefix}/', include(_core_urlpatterns)),
+    ] + _static_urlpatterns
+else:
+    urlpatterns = _core_urlpatterns + _static_urlpatterns


### PR DESCRIPTION
Este pull request corrige o carregamento de arquivos estáticos (CSS/JS) no Django Admin e o fluxo da documentação do Swagger para os ambientes de QA e Homologação.

O que foi feito:

Rotas e Estáticos: Isoladas as rotas da API (usando MS_PATH) das rotas de arquivos estáticos e media (agora na raiz /django_static/).
Swagger: Removida a view customizada (SwaggerFromFileView) e retomado o uso do padrão do drf-spectacular.
Segurança: Atualizado o ALLOWED_HOSTS e adicionado CSRF_TRUSTED_ORIGINS com os domínios oficiais de QA e Homolog (qa-api-sigla e hom-api-sigla).

[AB#146205](https://dev.azure.com/SME-Spassu/bd1a795a-42dd-4c65-8d4e-99a11b87f228/_workitems/edit/146205)
[AB#144155](https://dev.azure.com/SME-Spassu/bd1a795a-42dd-4c65-8d4e-99a11b87f228/_workitems/edit/144155)