### PR TITLE
feat(150060): extração de dados conta apenas o último lote importado

### DIFF
--- a/candidatos/service/extracao_dados_service.py
+++ b/candidatos/service/extracao_dados_service.py
@@ -1,11 +1,18 @@
-"""Agregações para a extração de dados de habilitados / convocados."""
+"""Agregações para a extração de dados de habilitados / convocados.
+
+Toda contagem parte sempre do **último lote importado** de cada concurso
+(o lote mais recente por ``criado_em``). Tanto para um concurso específico
+quanto para o agregado de todos os concursos, considera-se apenas o último
+lote vigente, garantindo regra única entre habilitados e convocados.
+"""
 
 from typing import Any
 from uuid import UUID
 
 from django.db.models import Count
+from django.db.models.query import QuerySet
 
-from candidatos.models import ConcursoCandidato
+from candidatos.models import ConcursoCandidato, ConcursoCandidatosLote
 
 CATEGORIAS = ("GERAL", "PCD", "NNA")
 
@@ -35,9 +42,7 @@ def montar_extracao_dados(
             habilitados_ano = _contar_habilitados_por_processos(
                 concurso_uuid, processo_uuids
             )
-            convocados = _contar_convocados(
-                concurso_uuid, processo_uuids
-            )
+            convocados = _contar_convocados(concurso_uuid, processo_uuids)
             resultado[ano] = {
                 "habilitados": habilitados_ano,
                 "convocados": convocados,
@@ -55,10 +60,85 @@ def montar_extracao_dados(
     return resultado
 
 
+def _uuids_ultimos_lotes(
+    concurso_uuid: UUID | str | None = None,
+) -> list[Any]:
+    """Resolve os ``uuid`` dos últimos lotes importados.
+
+    Args:
+        concurso_uuid: Concurso a restringir; ausente → último lote de cada
+            concurso distinto.
+
+    Returns:
+        Lista de ``uuid`` dos lotes vigentes (um por concurso). Vazia quando
+        não há lote no escopo.
+    """
+    if concurso_uuid:
+        lote = (
+            ConcursoCandidatosLote.objects.filter(concurso_uuid=concurso_uuid)
+            .order_by("-criado_em")
+            .first()
+        )
+        return [lote.uuid] if lote else []
+
+    # Sem concurso: o último lote (maior criado_em) de cada concurso. Itera do
+    # mais recente para o mais antigo e fica com o primeiro de cada concurso.
+    vistos: set[Any] = set()
+    uuids: list[Any] = []
+    lotes = ConcursoCandidatosLote.objects.order_by("-criado_em").values_list(
+        "concurso_uuid", "uuid"
+    )
+    for concurso, uuid_lote in lotes:
+        if concurso not in vistos:
+            vistos.add(concurso)
+            uuids.append(uuid_lote)
+    return uuids
+
+
+def _queryset_base(
+    concurso_uuid: UUID | str | None = None,
+) -> QuerySet[ConcursoCandidato]:
+    """Queryset canônico de habilitados (apenas os últimos lotes).
+
+    Args:
+        concurso_uuid: Concurso a restringir; ausente → todos os concursos.
+
+    Returns:
+        ``ConcursoCandidato`` filtrado pelos lotes vigentes do escopo.
+    """
+    return ConcursoCandidato.objects.filter(
+        lote__uuid__in=_uuids_ultimos_lotes(concurso_uuid)
+    )
+
+
+def _agregar_por_categoria(
+    qs: QuerySet[ConcursoCandidato],
+) -> dict[str, int]:
+    """Agrega a contagem por ``categoria_efetiva``.
+
+    Args:
+        qs: Queryset de ``ConcursoCandidato`` a agregar.
+
+    Returns:
+        Dicionário com o ``total`` e a quebra por ``geral`` / ``pcd`` /
+        ``nna``.
+    """
+    contagens = qs.values("categoria_efetiva").annotate(total=Count("uuid"))
+    por_categoria = {
+        item["categoria_efetiva"]: item["total"] for item in contagens
+    }
+    return {
+        "total": sum(por_categoria.values()),
+        "geral": por_categoria.get("GERAL", 0),
+        "pcd": por_categoria.get("PCD", 0),
+        "nna": por_categoria.get("NNA", 0),
+    }
+
+
 def _contar_habilitados(
     concurso_uuid: UUID | str | None = None,
 ) -> dict[str, int]:
-    """Conta habilitados por categoria efetiva.
+    """Conta habilitados por categoria efetiva no último lote.
 
     Args:
         concurso_uuid: Concurso a restringir; ausente → todos os concursos.
@@ -67,50 +147,35 @@ def _contar_habilitados(
         Dicionário com o ``total`` e a quebra por ``geral`` / ``pcd`` /
         ``nna``.
     """
-    qs = ConcursoCandidato.objects.all()
-    if concurso_uuid:
-        qs = qs.filter(lote__concurso_uuid=concurso_uuid)
-    contagens = qs.values("categoria_efetiva").annotate(total=Count("uuid"))
-    por_categoria = {
-        item["categoria_efetiva"]: item["total"] for item in contagens
-    }
-    return {
-        "total": sum(por_categoria.values()),
-        "geral": por_categoria.get("GERAL", 0),
-        "pcd": por_categoria.get("PCD", 0),
-        "nna": por_categoria.get("NNA", 0),
-    }
+    return _agregar_por_categoria(_queryset_base(concurso_uuid))
 
 
 def _contar_habilitados_por_processos(
     concurso_uuid: UUID | str | None = None,
     processo_uuids: list[UUID | str] | None = None,
 ) -> dict[str, int]:
-    """Conta habilitados por categoria no escopo dos processos informados."""
+    """Conta habilitados por categoria no escopo dos processos informados.
+
+    Args:
+        concurso_uuid: Concurso a restringir; ausente → todos os concursos.
+        processo_uuids: Processos a filtrar; vazio → zeros.
+
+    Returns:
+        Dicionário com o ``total`` e a quebra por ``geral`` / ``pcd`` /
+        ``nna`` no último lote, restrito aos processos informados.
+    """
     if not processo_uuids:
         return {"total": 0, "geral": 0, "pcd": 0, "nna": 0}
 
-    qs = ConcursoCandidato.objects.filter(processo_uuid__in=processo_uuids)
-    if concurso_uuid:
-        qs = qs.filter(lote__concurso_uuid=concurso_uuid)
-
-    contagens = qs.values("categoria_efetiva").annotate(total=Count("uuid"))
-    por_categoria = {
-        item["categoria_efetiva"]: item["total"] for item in contagens
-    }
-    return {
-        "total": sum(por_categoria.values()),
-        "geral": por_categoria.get("GERAL", 0),
-        "pcd": por_categoria.get("PCD", 0),
-        "nna": por_categoria.get("NNA", 0),
-    }
+    qs = _queryset_base(concurso_uuid).filter(processo_uuid__in=processo_uuids)
+    return _agregar_por_categoria(qs)
 
 
 def _contar_convocados(
     concurso_uuid: UUID | str | None = None,
     processo_uuids: list[UUID | str] | None = None,
 ) -> int:
-    """Conta ``foi_convocado=True``.
+    """Conta ``foi_convocado=True`` no último lote.
 
     Args:
         concurso_uuid: Concurso a restringir; ausente → todos os concursos.
@@ -121,9 +186,7 @@ def _contar_convocados(
     Returns:
         Quantidade de convocados no escopo informado.
     """
-    qs = ConcursoCandidato.objects.filter(foi_convocado=True)
-    if concurso_uuid:
-        qs = qs.filter(lote__concurso_uuid=concurso_uuid)
+    qs = _queryset_base(concurso_uuid).filter(foi_convocado=True)
     if processo_uuids is not None:
         qs = qs.filter(processo_uuid__in=processo_uuids)
     return qs.count()

--- a/candidatos/tests/views/test_habilitados_extracao_dados.py
+++ b/candidatos/tests/views/test_habilitados_extracao_dados.py
@@ -53,22 +53,25 @@ def test_extracao_dados_agrega_habilitados_e_convocados_por_ano(api_client):
     processo_2026 = uuid4()
     processo_2025 = uuid4()
 
-    # Dois lotes do mesmo concurso -> habilitados soma os dois
-    lote1 = ConcursoCandidatosLote.objects.create(
-        concurso_uuid=concurso_uuid, concurso_nome="Lote 1"
+    # Dois lotes do mesmo concurso -> conta apenas o ultimo (lote2)
+    lote_antigo = ConcursoCandidatosLote.objects.create(
+        concurso_uuid=concurso_uuid, concurso_nome="Lote antigo"
     )
-    lote2 = ConcursoCandidatosLote.objects.create(
-        concurso_uuid=concurso_uuid, concurso_nome="Lote 2"
+    lote = ConcursoCandidatosLote.objects.create(
+        concurso_uuid=concurso_uuid, concurso_nome="Lote vigente"
     )
 
-    # lote1: 2 GERAL (1 convocado 2026, 1 nao-convocado), 1 PCD nao-convocado
-    criar_concurso_candidato(lote1, "GERAL", True, processo_2026)
-    criar_concurso_candidato(lote1, "GERAL", False, None)
-    criar_concurso_candidato(lote1, "PCD", False, None)
+    # lote_antigo: candidatos de lote substituido -> NAO devem contar
+    criar_concurso_candidato(lote_antigo, "GERAL", True, processo_2026)
+    criar_concurso_candidato(lote_antigo, "PCD", True, processo_2025)
 
-    # lote2: 1 GERAL convocado 2025, 1 NNA nao-convocado
-    criar_concurso_candidato(lote2, "GERAL", True, processo_2025)
-    criar_concurso_candidato(lote2, "NNA", False, None)
+    # lote (vigente): 3 GERAL (1 conv 2026, 1 conv 2025, 1 nao-conv),
+    # 1 PCD nao-convocado, 1 NNA nao-convocado
+    criar_concurso_candidato(lote, "GERAL", True, processo_2026)
+    criar_concurso_candidato(lote, "GERAL", True, processo_2025)
+    criar_concurso_candidato(lote, "GERAL", False, None)
+    criar_concurso_candidato(lote, "PCD", False, None)
+    criar_concurso_candidato(lote, "NNA", False, None)
 
     # Candidato de outro concurso nao deve contar
     outro_lote = ConcursoCandidatosLote.objects.create(
@@ -89,7 +92,7 @@ def test_extracao_dados_agrega_habilitados_e_convocados_por_ano(api_client):
     assert resp.status_code == 200, resp.content
     data = resp.json()
 
-    # habilitados = todos os importados do concurso (5)
+    # habilitados = apenas os importados no ultimo lote do concurso (5)
     assert data["habilitados"] == {
         "total": 5,
         "geral": 3,
@@ -147,6 +150,7 @@ def test_extracao_dados_sem_filtros_retorna_total(api_client):
     # O agregado vem direto na raiz, sem a chave "total".
     assert data["convocados"] == 2
     assert data["nao-convocados"] == 2
+    # sem escolhas registradas -> os 2 convocados sao pendentes
     # nenhuma chave de ano presente
     assert set(data.keys()) == {"habilitados", "convocados", "nao-convocados"}
 
@@ -201,4 +205,49 @@ def test_extracao_dados_sem_concurso_agrega_todos(api_client):
     # convocados de todos os concursos (2)
     assert data["convocados"] == 2
     assert data["nao-convocados"] == 1
+    assert set(data.keys()) == {"habilitados", "convocados", "nao-convocados"}
+
+
+def test_extracao_dados_sem_concurso_usa_ultimo_lote_de_cada(api_client):
+    url = reverse("habilitados-extracao-dados")
+
+    # Concurso A: lote antigo (deve ser ignorado) + lote vigente
+    concurso_a = uuid4()
+    a_antigo = ConcursoCandidatosLote.objects.create(
+        concurso_uuid=concurso_a, concurso_nome="A antigo"
+    )
+    a_vigente = ConcursoCandidatosLote.objects.create(
+        concurso_uuid=concurso_a, concurso_nome="A vigente"
+    )
+    criar_concurso_candidato(a_antigo, "GERAL", True, uuid4())
+    criar_concurso_candidato(a_antigo, "PCD", True, uuid4())
+    criar_concurso_candidato(a_vigente, "GERAL", True, uuid4())
+    criar_concurso_candidato(a_vigente, "NNA", False, None)
+
+    # Concurso B: lote antigo (ignorado) + lote vigente
+    concurso_b = uuid4()
+    b_antigo = ConcursoCandidatosLote.objects.create(
+        concurso_uuid=concurso_b, concurso_nome="B antigo"
+    )
+    b_vigente = ConcursoCandidatosLote.objects.create(
+        concurso_uuid=concurso_b, concurso_nome="B vigente"
+    )
+    criar_concurso_candidato(b_antigo, "GERAL", True, uuid4())
+    criar_concurso_candidato(b_vigente, "PCD", True, uuid4())
+    criar_concurso_candidato(b_vigente, "GERAL", False, None)
+
+    resp = api_client.post(url, {}, format="json")
+
+    assert resp.status_code == 200, resp.content
+    data = resp.json()
+    # apenas os ultimos lotes de A e B: A=GERAL+NNA, B=PCD+GERAL
+    assert data["habilitados"] == {
+        "total": 4,
+        "geral": 2,
+        "pcd": 1,
+        "nna": 1,
+    }
+    # convocados nos ultimos lotes: A(GERAL) + B(PCD) = 2
+    assert data["convocados"] == 2
+    assert data["nao-convocados"] == 2
     assert set(data.keys()) == {"habilitados", "convocados", "nao-convocados"}


### PR DESCRIPTION
## Descrição

Ajusta a regra de contagem da extração de dados para considerar **apenas
o último lote importado** de cada concurso (o de maior `criado_em`), em
vez de somar todos os lotes históricos. A regra é única entre habilitados
e convocados e vale tanto para um concurso específico quanto para o
agregado de todos os concursos.

## Alterações

### Regra de negócio
- `_contar_habilitados`, `_contar_habilitados_por_processos` e
  `_contar_convocados` agora partem do queryset dos **lotes vigentes**,
  filtrando por `lote__uuid__in` em vez de `lote__concurso_uuid`.
- Sem concurso informado: usa o último lote de **cada** concurso distinto.

### Refatoração
- `_uuids_ultimos_lotes()` — resolve os `uuid` dos lotes vigentes do
  escopo (um por concurso).
- `_queryset_base()` — queryset canônico de habilitados, filtrado pelos
  lotes vigentes.
- `_agregar_por_categoria()` — agregação por `categoria_efetiva`,
  eliminando a duplicação que existia nas três contagens.
- Docstrings atualizadas (padrão Google) e tipagem com `QuerySet`.

[AB#151022](https://dev.azure.com/SME-Spassu/bd1a795a-42dd-4c65-8d4e-99a11b87f228/_workitems/edit/151022)
[AB#151024](https://dev.azure.com/SME-Spassu/bd1a795a-42dd-4c65-8d4e-99a11b87f228/_workitems/edit/151024)